### PR TITLE
Use/error message from fetch wxr response

### DIFF
--- a/src/rest-api/class-wp-rest-import-attachments.php
+++ b/src/rest-api/class-wp-rest-import-attachments.php
@@ -68,7 +68,8 @@ class WP_REST_Import_Attachments {
 		$body = json_decode( wp_remote_retrieve_body( $response ) );
 
 		if ( 200 !== $code ) {
-			return new WP_Error( 'wxr_fetch_failed', $body->message, array( 'status' => $code ) );
+			$message = $body->message ? $body->message : __( 'Could not retrieve an archive of the site', 'wordpress-importer' );
+			return new WP_Error( 'wxr_fetch_failed', $message, array( 'status' => $code ) );
 		}
 
 		return $body;

--- a/src/rest-api/class-wp-rest-import-attachments.php
+++ b/src/rest-api/class-wp-rest-import-attachments.php
@@ -65,12 +65,13 @@ class WP_REST_Import_Attachments {
 		}
 
 		$code = wp_remote_retrieve_response_code( $response );
+		$body = json_decode( wp_remote_retrieve_body( $response ) );
+
 		if ( 200 !== $code ) {
-			return new WP_Error( 'wxr_fetch_failed', 'Could not retrieve an archive of the site', array( 'status' => $code ) );
+			return new WP_Error( 'wxr_fetch_failed', $body->message, array( 'status' => $code ) );
 		}
 
-		$body = wp_remote_retrieve_body( $response );
-		return json_decode( $body );
+		return $body;
 	}
 
 	// @TODO: move to its own class


### PR DESCRIPTION
Previously, we were just using a hard-coded message.

If there is no message in the response, return the previous message (but wrap it in a translation function).

## Test

* Supply a supported site in the UI -- it should still "work"
* Supply an unsupported site in the UI -- the error message in the console should be different from the hard-coded string used previously.